### PR TITLE
change heptio -> vmware-tanzu

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -65,7 +65,7 @@ get_download_url() {
   local filename
   filename="$(get_filename "$version" "$platform" "$binary_name")"
 
-  echo "https://github.com/heptio/velero/releases/download/${version}/${filename}"
+  echo "https://github.com/vmware-tanzu/velero/releases/download/${version}/${filename}"
 }
 
 tmp_download_dir="$(mktemp -d -t 'asdf_XXXXXXXX')"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# https://github.com/heptio/velero/releases/download/v1.0.0/velero-v1.0.0-linux-amd64.tar.gz
-github_coordinates=heptio/velero
+# https://github.com/vmware-tanzu/velero/releases/download/v1.0.0/velero-v1.0.0-linux-amd64.tar.gz
+github_coordinates=vmware-tanzu/velero
 releases_path="https://api.github.com/repos/${github_coordinates}/releases"
 cmd="curl -s"
 if [ -n "$GITHUB_API_TOKEN" ]; then


### PR DESCRIPTION
a fresh install of `asdf-velero` would not list versions or install a particular version as the Github repo for velero has changed. This PR updates `asdf-velero` to use `https://github.com/vmware-tanzu/velero`.