### PR TITLE
remove leading v from version list output (fixes broken 'asdf latest velero')

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -5,7 +5,7 @@ set -o pipefail
 
 install_tool() {
   #local install_type=$1
-  local version=$2
+  local version="${2/v/}"
   local install_path=$3
   local tmp_download_dir=$4
   local binary_name=$5
@@ -43,7 +43,7 @@ get_binary_path_in_archive(){
   local version=$3
   local platform=$4
 
-  echo "$archive_dir/$binary_name-${version}-${platform}/$binary_name"
+  echo "$archive_dir/$binary_name-v${version}-${platform}/$binary_name"
 }
 
 get_platform() {
@@ -55,7 +55,7 @@ get_filename() {
   local platform="$2"
   local binary_name="$3"
 
-  echo "${binary_name}-${version}-${platform}.tar.gz"
+  echo "${binary_name}-v${version}-${platform}.tar.gz"
 }
 
 get_download_url() {
@@ -65,7 +65,7 @@ get_download_url() {
   local filename
   filename="$(get_filename "$version" "$platform" "$binary_name")"
 
-  echo "https://github.com/vmware-tanzu/velero/releases/download/${version}/${filename}"
+  echo "https://github.com/vmware-tanzu/velero/releases/download/v${version}/${filename}"
 }
 
 tmp_download_dir="$(mktemp -d -t 'asdf_XXXXXXXX')"

--- a/bin/list-all
+++ b/bin/list-all
@@ -16,6 +16,6 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//' | sort_versions)
+versions=$(eval "$cmd" | sed -En -e 's;\s*"tag_name": "v([0-9]+\.[0-9]+\.[0-9]+)",$;\1;p' | sort_versions)
 # shellcheck disable=SC2086
 echo $versions


### PR DESCRIPTION
The "latest" feature is currently broken for this plugin due to the version list output being prefixed with `v`, this PR fixes that.

Not working:

```
$ asdf list-all velero
v1.1.0-beta.1
v1.1.0
v1.1.0-beta.2
v1.2.0-beta.1
v1.2.0
v1.3.0-beta.1
v1.3.0-beta.2
v1.3.0
v1.3.1
v1.3.2
v1.4.0-beta.1
v1.4.0
v1.4.2
v1.4.3
v1.5.0-beta.1
v1.5.0-rc.1
v1.5.1
v1.5.2
v1.5.3
v1.5.4
v1.6.0-rc.1
v1.6.0-rc.2
v1.6.0
v1.6.1
v1.6.2
v1.6.3
v1.7.0-rc.1
v1.7.0
v1.7.1-rc.1
v1.7.1

$ asdf latest velero
No compatible versions available (velero [0-9])

$ asdf install velero latest
No compatible versions available (velero [0-9])
velero  is already installed
```

Working:

```
$ asdf list-all velero
1.1.0
1.2.0
1.3.0
1.3.1
1.3.2
1.4.0
1.4.2
1.4.3
1.5.1
1.5.2
1.5.3
1.5.4
1.6.0
1.6.1
1.6.2
1.6.3
1.7.0
1.7.1

$ asdf latest velero
1.7.1

$ asdf install velero latest
velero 1.7.1 is already installed
```