### PR TITLE
Add logic to detect system architecture by uname -m (arm, arm64, amd64)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -47,7 +47,14 @@ get_binary_path_in_archive(){
 }
 
 get_platform() {
-  echo "$(uname | tr '[:upper:]' '[:lower:]')-amd64"
+  arch=$(uname -m)
+  case $arch in
+    armv*) arch="arm";;
+    arm64) arch="arm64";; # m1 macs
+    aarch64) arch="arm64";;
+    *) arch="amd64";;
+  esac
+  echo "$(uname | tr '[:upper:]' '[:lower:]')-${arch}"
 }
 
 get_filename() {


### PR DESCRIPTION
Velero [publishes binaries](https://github.com/vmware-tanzu/velero/releases) for each system architecture, but this asdf plugin is currently hardcoded to `amd64`. The `amd64` binary doesn't work at all on linux-arm64 device. This change will use `uname -m` to detect the system architecture and pull the correct binary for each host. 

```bash
pi@arm64:~$ asdf plugin add velero
updating plugin repository...remote: Enumerating objects: 355, done.
remote: Counting objects: 100% (355/355), done.
remote: Compressing objects: 100% (186/186), done.
remote: Total 355 (delta 215), reused 293 (delta 168), pack-reused 0
Receiving objects: 100% (355/355), 110.09 KiB | 2.62 MiB/s, done.
Resolving deltas: 100% (215/215), completed with 1 local object.
From https://github.com/asdf-vm/asdf-plugins
   6d05a59..fe90d7a  master     -> origin/master
HEAD is now at fe90d7a feat: add asdf-gcc-arm-none-eabi plugin (#565)
pi@arm64:~$ asdf install velero v1.8.1
Downloading [velero] from https://github.com/vmware-tanzu/velero/releases/download/v1.8.1/velero-v1.8.1-linux-amd64.tar.gz to /tmp/asdf_WUtbuiCE/velero-v1.8.1-linux-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   669  100   669    0     0   2644      0 --:--:-- --:--:-- --:--:--  2654
100 28.2M  100 28.2M    0     0  6829k      0  0:00:04  0:00:04 --:--:-- 8674k
Creating bin directory
Cleaning previous binaries
Extracting archive
vCopying binary
pi@arm64:~$ velero
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
```

With the modification I made, you can see it will pull the arm64 tar'd binary from github in the curl output

```bash
pi@arm64:~$ asdf plugin add velero https://github.com/mathew-fleisch/asdf-velero.git
pi@arm64:~$ asdf install velero v1.8.1
Downloading [velero] from https://github.com/vmware-tanzu/velero/releases/download/v1.8.1/velero-v1.8.1-linux-arm64.tar.gz to /tmp/asdf_3R9yKd9G/velero-v1.8.1-linux-arm64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   669  100   669    0     0   2573      0 --:--:-- --:--:-- --:--:--  2563
100 26.1M  100 26.1M    0     0  11.3M      0  0:00:02  0:00:02 --:--:-- 14.5M
Creating bin directory
Cleaning previous binaries
Extracting archive
Copying binary
pi@arm64:~$ asdf global velero v1.8.1
pi@arm64:~$ velero
Velero is a tool for managing disaster recovery, specifically for Kubernetes
cluster resources. It provides a simple, configurable, and operationally robust
way to back up your application state and associated data.

If you're familiar with kubectl, Velero supports a similar model, allowing you to
execute commands such as 'velero get backup' and 'velero create schedule'. The same
operations can also be performed as 'velero backup get' and 'velero schedule create'.

Usage:
  velero [command]
  ...
```