### PR TITLE
[Install Script] darwin download url

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -48,12 +48,17 @@ get_binary_path_in_archive(){
 
 get_platform() {
   arch=$(uname -m)
-  case $arch in
-    armv*) arch="arm";;
-    arm64) arch="arm64";; # m1 macs
-    aarch64) arch="arm64";;
-    *) arch="amd64";;
-  esac
+  kernel_name=$(uname -s | tr '[:upper:]' '[:lower:]')
+  if [ "$kernel_name" == "linux" ]; then 
+    case $arch in
+      armv*) arch="arm";;
+      arm64) arch="arm64";; # m1 macs
+      aarch64) arch="arm64";;
+      *) arch="amd64";;
+    esac
+  else # darwin
+    arch="amd64"
+  fi
   echo "$(uname | tr '[:upper:]' '[:lower:]')-${arch}"
 }
 


### PR DESCRIPTION
Begin the outputs of

```
╰─$ uname -m
arm64
╰─$ uname -s
Darwin
```

The only available [release](https://github.com/vmware-tanzu/velero/releases?page=1) for darwin is `velero-xxxx-darwin-amd64.tar.gz` ( see for example [latest release](https://github.com/vmware-tanzu/velero/releases/download/v1.9.2-rc.1/velero-v1.9.2-rc.1-darwin-amd64.tar.gz))

Full Machine spec
```
╰─$ system_profiler SPSoftwareDataType SPHardwareDataType                                                                                                                                      
Software:

    System Software Overview:

      System Version: macOS 12.3 (21E230)
      Kernel Version: Darwin 21.4.0
      Boot Volume: Macintosh HD
      Boot Mode: Normal
      Computer Name: flash
      User Name: Carlos Rodriguez López (carlosrodlop)
      Secure Virtual Memory: Enabled
      System Integrity Protection: Enabled
      Time since boot: 6:32

Hardware:

    Hardware Overview:

      Model Name: MacBook Pro
      Model Identifier: MacBookPro18,2
      Chip: Apple M1 Max
      Total Number of Cores: 10 (8 performance and 2 efficiency)
      Memory: 32 GB
      System Firmware Version: 7459.101.2
      OS Loader Version: 7459.101.2
      Serial Number (system): Q5V6C65CXX
      Hardware UUID: 32B3B044-4E97-590E-A3F1-E3F52CBA2F68
      Provisioning UDID: 00006001-001468A93A42401E
      Activation Lock Status: Disabled
```

